### PR TITLE
bugfix: 调整github油猴脚本的拦截配置，修复在先访问其他页面（如：issue、PR页面），再通过tab切换到code页面时，由于页面是局部刷新，导致油猴脚本未加载的问题。

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -61,7 +61,7 @@ module.exports = {
         '/.*/.*/blame/': {
           redirect: 'gh.api.99988866.xyz/https://github.com'
         },
-        '^/[^/]+/[^/]+(/releases(/.*)?)?$': {
+        '^(/[^/]+){2}([/?].*)?$': {
           script: [
             'github'
           ],


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：
bugfix: 调整github油猴脚本的拦截配置，修复在先访问其他页面（如：issue、PR页面），再通过tab切换到code页面时，由于页面是局部刷新，导致油猴脚本未加载的问题。

### Ⅱ. 此PR修复了哪个issue吗？
<!-- 如果是的话, 请在下一行写上 "fixes #xxx"，比如：fixes #97 -->
fixes #288
