### PR TITLE
feature: 篡改猴插件地址，可以自定义配置了。

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -56,7 +56,11 @@ module.exports = {
           sni: 'baidu.com'
         },
         '^(/[\\w-.]+){2,}/?(\\?.*)?$': {
+          // 自定义篡改猴插件地址配置
+          tampermonkeyScript: 'https://mirror.ghproxy.com/https://raw.githubusercontent.com/docmirror/dev-sidecar/scripts/tampermonkey.js',
+          // 脚本地址配置
           script: [
+            // Github油猴脚本
             'https://mirror.ghproxy.com/https://raw.githubusercontent.com/docmirror/dev-sidecar/scripts/github/monkey.js'
           ],
           scriptUrlDesc: '上面所使用的脚本地址，使用了高速镜像地址。',

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -63,7 +63,7 @@ module.exports = {
             // Github油猴脚本
             'https://mirror.ghproxy.com/https://raw.githubusercontent.com/docmirror/dev-sidecar/scripts/github/monkey.js'
           ],
-          scriptUrlDesc: '上面所使用的脚本地址，使用了高速镜像地址。',
+          remark: '注：上面所使用的脚本地址，为高速镜像地址。',
           desc: '油猴脚本：高速下载 Git Clone/SSH、Release、Raw、Code(ZIP) 等文件 (公益加速)、项目列表单文件快捷下载、添加 git clone 命令'
         },
         // 以下三项暂时先注释掉，因为已经有油猴脚本提供高速下载地址了。

--- a/packages/mitmproxy/src/lib/interceptor/impl/res/script.js
+++ b/packages/mitmproxy/src/lib/interceptor/impl/res/script.js
@@ -93,7 +93,7 @@ module.exports = {
       const hostnameConfig = intercepts[hostnamePattern]
 
       const scriptProxy = {}
-      const handleScript = (scriptUrl, name, replaceScriptUrlFun) => {
+      const handleScriptUrl = (scriptUrl, name, replaceScriptUrlFun) => {
         if (scriptUrl.indexOf('https:') === 0 || scriptUrl.indexOf('http:') === 0) {
           // 绝对地址
           const scriptKey = SCRIPT_PROXY_URL_PRE + scriptUrl.replace('.js', '').replace(/[\W_]+/g, '_') + '.js' // 伪脚本地址：移除 script 中可能存在的特殊字符，并转为相对地址
@@ -112,7 +112,7 @@ module.exports = {
         if (typeof pathConfig.script === 'object' && pathConfig.script.length > 0) {
           for (let i = 0; i < pathConfig.script.length; i++) {
             const scriptUrl = pathConfig.script[i]
-            handleScript(scriptUrl, 'script', (scriptKey) => {
+            handleScriptUrl(scriptUrl, 'script', (scriptKey) => {
               pathConfig.script[i] = scriptKey
             })
           }
@@ -120,7 +120,7 @@ module.exports = {
 
         // 处理 tampermonkeyScript 配置
         if (typeof pathConfig.tampermonkeyScript === 'string') {
-          handleScript(pathConfig.tampermonkeyScript, 'tampermonkey', (scriptKey) => {
+          handleScriptUrl(pathConfig.tampermonkeyScript, 'tampermonkey', (scriptKey) => {
             pathConfig.tampermonkeyScript = scriptKey
           })
         }


### PR DESCRIPTION
feature: 篡改猴插件，可以自定义配置地址了。

---

配置方式如下：
```json
{
  "github.com": {
    "^(/[\\w-.]+){2,}/?(\\?.*)?$": {
      // 自定义篡改猴插件地址配置
      "tampermonkeyScript": "https://mirror.ghproxy.com/https://raw.githubusercontent.com/docmirror/dev-sidecar/scripts/tampermonkey.js",
      "script": [
        // Github油猴脚本
        "https://mirror.ghproxy.com/https://raw.githubusercontent.com/docmirror/dev-sidecar/scripts/github/monkey.js"
      ]
    }
  }
}
```