### PR TITLE
optimize: 兼容使用 `1.7.3` 及以下版本的配置文件

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -23,15 +23,23 @@ function _getRemoteSavePath (suffix = '') {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
   }
-  return path.join(dir, `remote_config${suffix}.json5`)
+  return path.join(dir, `/remote_config${suffix}.json5`)
 }
 
 function _getConfigPath () {
   const dir = getDefaultConfigBasePath()
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
+  } else {
+    // 兼容1.7.3及以下版本的配置文件处理逻辑
+    const newFilePath = path.join(dir, '/config.json')
+    const oldFilePath = path.join(dir, '/config.json5')
+    if (!fs.existsSync(newFilePath) && fs.existsSync(oldFilePath)) {
+      return oldFilePath // 如果新文件不存在，且旧文件存在，则返回旧文件路径
+    }
+    return newFilePath
   }
-  return path.join(dir, 'config.json')
+  return path.join(dir, '/config.json')
 }
 
 let timer

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -6,11 +6,11 @@ function getUserBasePath () {
 }
 
 function getRootCaCertPath () {
-  return getUserBasePath() + '/dev-sidecar.ca.crt'
+  return path.join(getUserBasePath(), '/dev-sidecar.ca.crt')
 }
 
 function getRootCaKeyPath () {
-  return getUserBasePath() + '/dev-sidecar.ca.key.pem'
+  return path.join(getUserBasePath(), '/dev-sidecar.ca.key.pem')
 }
 
 module.exports = {

--- a/packages/gui/src/bridge/api/backend.js
+++ b/packages/gui/src/bridge/api/backend.js
@@ -138,8 +138,16 @@ function _getSettingsPath () {
   const dir = getDefaultConfigBasePath()
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
+  } else {
+    // 兼容1.7.3及以下版本的配置文件处理逻辑
+    const newFilePath = path.join(dir, '/setting.json')
+    const oldFilePath = path.join(dir, '/setting.json5')
+    if (!fs.existsSync(newFilePath) && fs.existsSync(oldFilePath)) {
+      return oldFilePath // 如果新文件不存在，且旧文件存在，则返回旧文件路径
+    }
+    return newFilePath
   }
-  return dir + '/setting.json'
+  return path.join(dir, '/setting.json')
 }
 
 function invoke (api, param) {


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：
optimize: 兼容使用 `1.7.3` 及以下版本的配置文件

> 由于 `1.8.0` 版本，对 `~/.dev-sidecar/config.json5` 和 `~/.dev-sidecar/setting.json5` 两个配置文件名进行了后缀名修改，由 `.json5` 修改为 `.json`，导致从`1.7.3` 及以下版本升级上来的用户，无法继续使用 `.json5` 配置文件中的内容，而产生了丢失配置的现象，现修复此问题。


### Ⅱ. 此PR修复了哪个issue吗？
<!-- 如果是的话, 请在下一行写上 "fixes #xxx"，比如：fixes #97 -->


### Ⅲ. 界面变化截屏
<!-- 如果存在界面上的变化，请截屏展示出来 -->
