### PR TITLE
README错误，更改旧淘宝npm域名为新的

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ npm config delete https-proxy
 ```shell
 npm install -g cnpm --registry=https://registry.npmmirror.com
 
-cnpm install lerna@6 -g
+cnpm install -g lerna@6
 
 ```
 
@@ -367,7 +367,7 @@ cd dev-sidecar
 # 注意不要使用 `npm install` 来安装依赖，因为 `lerna bootstrap` 会自动安装依赖
 lerna bootstrap
 # 如果 `lerna bootstrap` 有报错，可以尝试执行如下两行命令，用yarn替换掉npm：
-#cnpm install yarn -g
+#cnpm install -g yarn
 #lerna bootstrap --npm-client=yarn
 
 # 运行DevSidecar

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ npm config delete https-proxy
 运行如下命令即可安装所需依赖：
 > 注：lerna指定为6.x版本，更高版本会导致打包失败（不兼容导致）
 ```shell
- npm install -g cnpm --registry=https://registry.npmmirror.com
+npm install -g cnpm --registry=https://registry.npmmirror.com
 
 cnpm install lerna@6 -g
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ npm config delete https-proxy
 运行如下命令即可安装所需依赖：
 > 注：lerna指定为6.x版本，更高版本会导致打包失败（不兼容导致）
 ```shell
-npm install cnpm -g --registry=https://registry.npm.taobao.org
+ npm install -g cnpm --registry=https://registry.npmmirror.com
 
 cnpm install lerna@6 -g
 


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：
README错误，更改旧淘宝npm域名为新的，旧的npm域名DNS已不再解析

### Ⅱ. 此PR修复了哪个issue吗？
<!-- 如果是的话, 请在下一行写上 "fixes #xxx"，比如：fixes #97 -->


### Ⅲ. 界面变化截屏
<!-- 如果存在界面上的变化，请截屏展示出来 -->
