### PR TITLE
添加*.github.dev、*.gitbook.io和*.gitbook.com

### DIFF
--- a/packages/core/src/modules/plugin/overwall/config.js
+++ b/packages/core/src/modules/plugin/overwall/config.js
@@ -10,6 +10,7 @@ module.exports = {
     },
   },
   targets: {
+    '*.gitbook.com': true,
     '*.gitbook.io': true,
     '*.github.dev': true,
     '*.github.com': true,

--- a/packages/core/src/modules/plugin/overwall/config.js
+++ b/packages/core/src/modules/plugin/overwall/config.js
@@ -10,6 +10,8 @@ module.exports = {
     },
   },
   targets: {
+    '*.gitbook.io': true,
+    '*.github.dev': true,
     '*.github.com': true,
     '*github*.com': true,
     '*.wikimedia.org': true,


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：

添加`*.github.dev`、`*.gitbook.io`和`*.gitbook.com`，从而实现在增强模式下可以登录gitbook、查看别人写的gitbook

### Ⅲ. 效果变化截屏

![image](https://github.com/user-attachments/assets/1ab43f75-ef2f-43df-b375-bd3df5814ddc)

![image](https://github.com/user-attachments/assets/4d27ccfa-07c7-4540-9be9-81781acc7a3a)
