### PR TITLE
optimize: linux允许隐藏窗口了，前提是先设置好快捷键

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -23,6 +23,7 @@ const defaultConfig = {
       personalUrl: '',
     },
     startShowWindow: true, // 启动时是否打开窗口：true=打开窗口, false=隐藏窗口
+    needCheckHideWindow: true, // 是否需要在隐藏窗口时做检查
     showHideShortcut: 'Alt + S', // 显示/隐藏窗口快捷键
     windowSize: { width: 900, height: 750 }, // 启动时，窗口的尺寸
     theme: 'dark', // 主题：light=亮色, dark=暗色

--- a/packages/gui/src/background.js
+++ b/packages/gui/src/background.js
@@ -170,7 +170,7 @@ function checkHideWin () {
   return true
 }
 
-function hideWin (reason = '', needCheck = true) {
+function hideWin (reason = '', needCheck = false) {
   if (win) {
     if (needCheck && !checkHideWin()) {
       return
@@ -255,7 +255,7 @@ function createWindow (startHideWindow, autoQuitIfError = true) {
   }
 
   if (startHideWindow) {
-    hideWin('startHideWindow', false)
+    hideWin('startHideWindow')
   }
 
   win.on('closed', async (...args) => {
@@ -268,7 +268,7 @@ function createWindow (startHideWindow, autoQuitIfError = true) {
     if (message.value === 1) {
       quit('ipc receive "close"')
     } else {
-      hideWin('ipc receive "close"')
+      hideWin('ipc receive "close"', true)
     }
   })
 
@@ -285,7 +285,7 @@ function createWindow (startHideWindow, autoQuitIfError = true) {
       quit('win close')
     } else if (closeStrategy === 2) {
       // 隐藏窗口
-      hideWin('win close')
+      hideWin('win close', true)
     } else {
       // 弹窗提示，选择关闭策略
       win.webContents.send('close.showTip', { closeStrategy, showHideShortcut: config.app.showHideShortcut })
@@ -381,7 +381,7 @@ function registerShowHideShortcut (showHideShortcut) {
           if (!win.isFocused()) {
             win.focus() // 如果窗口打开着，但没有获取焦点，则获取焦点，而不是hide
           } else {
-            hideWin('shortcut', false) // 快捷键隐藏窗口，不需要提示
+            hideWin('shortcut')
           }
         }
       })

--- a/packages/gui/src/background.js
+++ b/packages/gui/src/background.js
@@ -255,7 +255,7 @@ function createWindow (startHideWindow, autoQuitIfError = true) {
   }
 
   if (startHideWindow) {
-    hideWin('startHideWindow')
+    hideWin('startHideWindow', false)
   }
 
   win.on('closed', async (...args) => {

--- a/packages/gui/src/background.js
+++ b/packages/gui/src/background.js
@@ -9,10 +9,12 @@ import backend from './bridge/backend'
 import jsonApi from '@docmirror/mitmproxy/src/json'
 import log from './utils/util.log'
 
-log.info('background.js start')
+log.info(`background.js start, platform is ${process.platform}`)
 
 const isWindows = process.platform === 'win32'
+const isLinux = process.platform === 'linux'
 const isMac = process.platform === 'darwin'
+
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
 // 避免其他系统出现异常，只有 Windows 使用 './background/powerMonitor'
@@ -146,24 +148,41 @@ function setTray () {
   return appTray
 }
 
-function isLinux () {
-  const platform = DevSidecar.api.shell.getSystemPlatform()
-  return platform === 'linux'
+function checkHideWin () {
+  const config = DevSidecar.api.config.get()
+
+  // 配置为false时，不需要校验
+  if (!config.app.needCheckHideWindow) {
+    return true
+  }
+
+  // 如果是linux，且没有设置快捷键，则提示先设置快捷键
+  if (isLinux && !hasShortcut(config.app.showHideShortcut)) {
+    dialog.showMessageBox({
+      type: 'info',
+      title: '提示：请先设置快捷键',
+      message: '由于大部分 Linux 系统没有系统托盘，所以需使用快捷键呼出窗口。\n但您还未设置快捷键，请先到 “设置” 页面中设置好快捷键，再关闭窗口。',
+      buttons: ['确定'],
+    })
+    return false
+  }
+
+  return true
 }
 
-function hideWin (reason = '') {
+function hideWin (reason = '', needCheck = true) {
   if (win) {
-    if (isLinux()) {
-      quit(`is linux, not hide win, do quit, ${reason}`)
+    if (needCheck && !checkHideWin()) {
       return
     }
+
     win.hide()
     if (isMac && hideDockWhenWinClose) {
       app.dock.hide()
     }
     winIsHidden = true
   } else {
-    log.warn('win is null, do not hide win')
+    log.warn(`win is null, do not hide win, reason: ${reason}`)
   }
 }
 
@@ -259,21 +278,17 @@ function createWindow (startHideWindow, autoQuitIfError = true) {
       return
     }
     e.preventDefault()
-    if (isLinux()) {
-      quit('win close')
-      return
-    }
     const config = DevSidecar.api.config.get()
     const closeStrategy = config.app.closeStrategy
-    if (closeStrategy === 0) {
-      // 弹窗提示，选择关闭策略
-      win.webContents.send('close.showTip', closeStrategy)
-    } else if (closeStrategy === 1) {
+    if (closeStrategy === 1) {
       // 直接退出
       quit('win close')
     } else if (closeStrategy === 2) {
       // 隐藏窗口
       hideWin('win close')
+    } else {
+      // 弹窗提示，选择关闭策略
+      win.webContents.send('close.showTip', { closeStrategy, showHideShortcut: config.app.showHideShortcut })
     }
   })
 
@@ -351,22 +366,22 @@ async function quit (reason) {
   app.quit()
 }
 
+function hasShortcut (showHideShortcut) {
+  return showHideShortcut && showHideShortcut.length > 1
+}
+
 function registerShowHideShortcut (showHideShortcut) {
   globalShortcut.unregisterAll()
-  if (showHideShortcut && showHideShortcut !== '无' && showHideShortcut.length > 1) {
+  if (hasShortcut(showHideShortcut)) {
     try {
       const registerSuccess = globalShortcut.register(DevSidecar.api.config.get().app.showHideShortcut, () => {
-        if (winIsHidden || !win.isFocused()) {
-          if (!win.isFocused()) {
-            win.focus()
-          }
-          if (winIsHidden) {
-            showWin()
-          }
+        if (winIsHidden) {
+          showWin()
         } else {
-          // linux，快捷键不关闭窗口
-          if (!isLinux()) {
-            hideWin()
+          if (!win.isFocused()) {
+            win.focus() // 如果窗口打开着，但没有获取焦点，则获取焦点，而不是hide
+          } else {
+            hideWin('shortcut', false) // 快捷键隐藏窗口，不需要提示
           }
         }
       })

--- a/packages/gui/src/bridge/on-close/front.js
+++ b/packages/gui/src/bridge/on-close/front.js
@@ -1,4 +1,4 @@
-let closeType = 1
+let closeType = 2
 let doSave = false
 
 function install (app, api) {
@@ -25,10 +25,14 @@ function install (app, api) {
               记住本次选择，不再提示
             </a-checkbox>
           </div>
+          <div style="margin-top:20px">
+            提示：打开窗口的快捷键为
+            <code>{message.showHideShortcut || '无'}</code>
+          </div>
         </div>
       ),
       async onOk () {
-        console.log('OK. closeType=', closeType)
+        console.log('OK. closeType=', closeType, ', doSave:', doSave)
         if (doSave) {
           await api.config.update({ app: { closeStrategy: closeType } })
         }

--- a/packages/gui/src/view/api.js
+++ b/packages/gui/src/view/api.js
@@ -14,7 +14,7 @@ export function apiInit (app) {
     })
   }
   const send = (channel, message) => {
-    console.log('do send,', channel, message)
+    console.log('ipcRenderer.send, channel=', channel, ', message=', message)
     return ipcRenderer.send(channel, message)
   }
 


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：

optimize: linux允许隐藏窗口，但必须先设置好快捷键

> 注：以前不允许linux关闭窗口是因为linux没有系统托盘，无法呼出窗口，现在有快捷键了，可以呼出窗口了。

### Ⅱ. 此PR修复了哪个issue吗？

<!-- 如果是的话，请在下一行写上 "fixes #xxx"，比如：fixes #97 -->
fixes #259
fixes #444
