### PR TITLE
修复Github脚本/页面加载问题

### DIFF
--- a/packages/gui/src/view/App.vue
+++ b/packages/gui/src/view/App.vue
@@ -178,7 +178,7 @@ export default {
           </a-layout-content>
           <a-layout-footer>
             <div class="footer">
-              ©2020-2025 docmirror.cn by <a @click="openExternal('https://github.com/greper')">Greper</a>, <a @click="openExternal('https://github.com/wangliang181230')">WangLiang</a>  <span>{{ info.version }}.2</span>
+              ©2020-2025 docmirror.cn by <a @click="openExternal('https://github.com/greper')">Greper</a>, <a @click="openExternal('https://github.com/wangliang181230')">WangLiang</a>  <span>{{ info.version }}.3</span>
             </div>
           </a-layout-footer>
         </a-layout>

--- a/packages/mitmproxy/src/lib/interceptor/impl/res/script.js
+++ b/packages/mitmproxy/src/lib/interceptor/impl/res/script.js
@@ -74,6 +74,9 @@ module.exports = {
       } else {
         tags = `\r\n\t${getScript('tampermonkey', scripts.tampermonkey.script)}${tags}`
       }
+      
+      // 增加一个假的js文件，避免github的js异步加载策略获得错误的根路径
+      tags = `\r\n\t${tags}${getScriptByUrlOrPath(" https://github.githubassets.com/assets/fakefile.js ")}`
 
       res.setHeader('DS-Script-Interceptor', 'true')
       log.info(`script response intercept: insert script ${rOptions.protocol}//${rOptions.hostname}:${rOptions.port}${rOptions.path}`, ', head:', tags)


### PR DESCRIPTION
### Ⅰ. 描述此PR的作用：

修复了Github的js异步加载策略由于脚本路径不同，获得错误的根路径导致页面加载错误

### Ⅱ. 此PR修复了哪个issue吗？

#548 #549 #558

### Ⅲ. 界面变化截屏

无