### PR TITLE
fix(update): 更改获取GitHub的更新逻辑

### DIFF
--- a/packages/gui/src/bridge/update/backend.js
+++ b/packages/gui/src/bridge/update/backend.js
@@ -18,7 +18,7 @@ const curVersion = pkg.version
 const isCurrentPreRelease = curVersion.includes('-')
 
 function extractVersion (versionData) {
-  const candidates = [versionData.name, versionData.tag_name]
+  const candidates = [versionData.tag_name, versionData.name]
   for (const candidate of candidates) {
     if (!candidate) {
       continue


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/xinvxueyuan/dev-sidecar/sessions/a909d7f0-3913-425f-b777-52a8a22c7189

Co-authored-by: xinvxueyuan <149921651+xinvxueyuan@users.noreply.github.com>

fix #579 and close #579 