### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/packages/mitmproxy/src/utils/util.match.js
+++ b/packages/mitmproxy/src/utils/util.match.js
@@ -38,7 +38,7 @@ function domainRegexply (target) {
   if (target === '.*' || target === '*' || target === 'true' || target === true) {
     return '^.*$'
   }
-  return `^${target.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`
+  return `^${target.replace(/\\/g, '\\\\').replace(/\./g, '\\.').replace(/\*/g, '.*')}$`
 }
 
 function domainMapRegexply (hostMap) {


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/7](https://github.com/docmirror/dev-sidecar/security/code-scanning/7)

The safest fix is to escape backslashes before other regex-relevant substitutions, while preserving existing behavior (`*` remains wildcard -> `.*`, `.` remains literal -> `\.`).  
In `packages/mitmproxy/src/utils/util.match.js`, update `domainRegexply` line 41 so it first escapes `\` globally, then escapes dots, then converts `*` to `.*`.

Concretely:
- Change:
  - ``target.replace(/\./g, '\\.').replace(/\*/g, '.*')``
- To:
  - ``target.replace(/\\/g, '\\\\').replace(/\./g, '\\.').replace(/\*/g, '.*')``

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
