### PR TITLE
Potential fix for code scanning alert no. 9: Disabling certificate validation

### DIFF
--- a/packages/mitmproxy/src/index.js
+++ b/packages/mitmproxy/src/index.js
@@ -17,11 +17,7 @@ const api = {
       }
     }
 
-    if (proxyOptions.setting && proxyOptions.setting.NODE_TLS_REJECT_UNAUTHORIZED === false) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-    } else {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
-    }
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
     // log.info('启动代理服务时的配置:', JSON.stringify(proxyOptions, null, '\t'))
     const newServers = mitmproxy.createProxy(proxyOptions, (server, port, host, ssl) => {
       fireStatus(true)


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/9](https://github.com/docmirror/dev-sidecar/security/code-scanning/9)

In general, fix this by **never disabling TLS certificate validation globally** via `NODE_TLS_REJECT_UNAUTHORIZED='0'`. Keep validation enabled (`'1'`) and, if needed in special test scenarios, use scoped trust configuration (for example custom CA/cert options on specific TLS clients) rather than process-wide bypass.

Best minimal fix in this file: replace the conditional branch that sets `'0'` with logic that always enforces `'1'`. This preserves startup behavior and avoids introducing new dependencies or broad refactors, while removing the insecure path.  
Specifically, in `packages/mitmproxy/src/index.js` around lines 20–24, replace the `if/else` block with a single assignment:

- `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'`

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
