### PR TITLE
fix: add proper error code for proxy timeout and handle missing e.code in error template

### DIFF
--- a/packages/mitmproxy/src/lib/proxy/mitmproxy/createRequestHandler.js
+++ b/packages/mitmproxy/src/lib/proxy/mitmproxy/createRequestHandler.js
@@ -186,6 +186,7 @@ module.exports = function createRequestHandler (createIntercepts, middlewares, e
             proxyReq.end()
             proxyReq.destroy()
             const error = new Error(errorMsg)
+            error.code = 'ETIMEOUT'
             error.status = 408
             reject(error)
           })
@@ -343,7 +344,7 @@ module.exports = function createRequestHandler (createIntercepts, middlewares, e
             }
           </style>
           <p>DevSidecar Error:</p>
-          <p>目标网站请求错误：【${e.code}】 ${e.message}</p>
+          <p>目标网站请求错误：【${e.code || (e.status || 'UNKNOWN')}】 ${e.message}</p>
           <p>目标地址：${rOptions.protocol}//${rOptions.hostname}:${rOptions.port}${rOptions.path}</p>`,
           )
         } catch {


### PR DESCRIPTION
## Root Cause

When a proxy request times out (e.g., due to network issues or slow upstream), the timeout error object was created without a `code` property:

```js
const error = new Error(errorMsg)
error.status = 408
reject(error)
```

This caused the error page to display `【undefined】` in the error code field, making it hard for users and developers to identify the error type.

## Fix

1. Added `error.code = 'ETIMEOUT'` to the timeout error, so the error page now shows `【ETIMEOUT】` instead of `【undefined】`.

2. Updated the error page template to use `e.code || (e.status || 'UNKNOWN')` as a fallback chain, preventing `undefined` from appearing in any future errors that might lack a `code` property.

## Testing

1. Set up dev-sidecar with a proxy that points to a slow/unreachable upstream
2. Browse a proxied site (e.g., google.com)
3. Wait for the 20s timeout
4. Observe error page now shows `【ETIMEOUT】` instead of `【undefined】`

Closes #638