### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,6 +14,9 @@ on:
       - "**/LICENSE"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   # job 1
   build-and-upload:


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/17](https://github.com/docmirror/dev-sidecar/security/code-scanning/17)

Add an explicit `permissions` block in `.github/workflows/build-and-release.yml` at the workflow root (after `on:` and before `jobs:`), so all jobs inherit least-privilege defaults.  
Given this workflow builds artifacts and performs a release step, the safest non-breaking baseline here is:

- `contents: write` (needed for creating/updating releases and uploading release assets)
- (other scopes default to `none` when any permission is specified)

This preserves expected release behavior while still removing unnecessary token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
