### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-run-electron.yml
+++ b/.github/workflows/npm-run-electron.yml
@@ -14,6 +14,9 @@ on:
       - "**/LICENSE"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   npm-run-electron:
     runs-on: ${{ contains(matrix.os, '-arm') && matrix.os || format('{0}-latest', matrix.os) }}


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/18](https://github.com/docmirror/dev-sidecar/security/code-scanning/18)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `npm-run-electron`) unless overridden.  
For this workflow, the safest minimal non-breaking fix from the shown steps is:

- `contents: read`

This supports repository checkout and keeps token privileges limited.  
Edit `.github/workflows/npm-run-electron.yml` near the top-level keys: insert `permissions:` after `on:` block (or before `jobs:`) at root indentation level.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
