### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -1,5 +1,8 @@
 name: "Test And Upload"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/21](https://github.com/docmirror/dev-sidecar/security/code-scanning/21)

Add an explicit `permissions` block at the workflow root in `.github/workflows/test-and-upload.yml`, directly under `name` (before `on:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline requested by CodeQL is:

- `contents: read`

This preserves existing behavior for checkout and general read operations while documenting and enforcing least privilege. If future steps require additional scopes, they can be added narrowly at job-level or workflow-level then.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
