### PR TITLE
Potential fix for code scanning alert no. 26: Insecure randomness

### DIFF
--- a/packages/gui/src/view/components/JsonEditor.vue
+++ b/packages/gui/src/view/components/JsonEditor.vue
@@ -15,7 +15,7 @@ const emit = defineEmits(['update:modelValue', 'json-save', 'has-error'])
 
 const containerRef = ref(null)
 let editor = null
-const uid = `jsoneditor-${Math.random().toString(36).slice(2, 9)}`
+const uid = `jsoneditor-${crypto.getRandomValues(new Uint32Array(1))[0].toString(36)}`
 
 function initEditor () {
   if (!containerRef.value) {


### PR DESCRIPTION
Potential fix for [https://github.com/docmirror/dev-sidecar/security/code-scanning/26](https://github.com/docmirror/dev-sidecar/security/code-scanning/26)

Use a cryptographically secure source for the random suffix used in `uid` generation. In browser Vue code, the correct primitive is `crypto.getRandomValues`. This keeps behavior the same (a short unique-ish ID string) while removing `Math.random()`.

Best fix in this file:
- Edit `packages/gui/src/view/components/JsonEditor.vue` at the `uid` definition region.
- Replace `Math.random().toString(36).slice(2, 9)` with a CSPRNG-derived value, e.g. one 32-bit random integer converted to base36.
- No new npm dependency is needed; use built-in Web Crypto API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
