### PR TITLE
fix: 修复 README 中损坏的 star history 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href='https://github.com/docmirror/dev-sidecar'><img alt="GitHub stars" src="https://img.shields.io/github/stars/docmirror/dev-sidecar?logo=github&cacheSeconds=86400"></a>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=docmirror/dev-sidecar&type=date&legend=top-left)](https://www.star-history.com/#docmirror/dev-sidecar&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=docmirror/dev-sidecar&type=date&legend=top-left)](https://star-history.dera.page/#docmirror/dev-sidecar&type=date&legend=top-left)
 
 > Gitee上的同步项目已被封禁，请认准本项目唯一官方仓库地址[https://github.com/docmirror/dev-sidecar](https://github.com/docmirror/dev-sidecar) 【狗头保命】
 >


### PR DESCRIPTION
当前 README 中的 star history 图表因 GitHub stargazer API 限制已经无法正常显示，本项目大量用户（star 数一万多）在仓库首页看不到该图表。

此 PR 将图表链接更换到使用替代数据源的新服务地址（无需 API token，图表即可恢复显示）。

请考虑合并此修复，谢谢！